### PR TITLE
feat: add impressionsEnabled option

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 
 .npm_install:
   before_script: &npm_install
-    - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN_RO}' > .npmrc
+    - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
     - npm i
 
 npm:

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -38,7 +38,9 @@ const base = {
     // traffic type for the given key (only used on browser version)
     trafficType: undefined,
     // toggle impressions tracking of labels
-    labelsEnabled: true
+    labelsEnabled: true,
+    // toggle all impressions tracking
+    impressionsEnabled: true
   },
 
   scheduler: {

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -38,7 +38,8 @@ interface ISettings {
     authorizationKey: string,
     key: SplitIO.SplitKey,
     trafficType: string,
-    labelsEnabled: boolean
+    labelsEnabled: boolean,
+    impressionsEnabled: boolean,
   },
   readonly mode: SDKMode,
   readonly scheduler: {
@@ -213,7 +214,13 @@ interface INodeBasicSettings extends ISharedSettings {
      * @property {boolean} labelsEnabled
      * @default true
      */
-    labelsEnabled?: boolean
+    labelsEnabled?: boolean,
+    /**
+     * Disable impressions from being sent to Split backend. Should only be used to prevent duplicate tracking in situations like SSR.
+     * @property {boolean} impressionsEnabled
+     * @default true
+     */
+    impressionsEnabled?: boolean,
   },
   /**
    * Defines which kind of storage we should instanciate.
@@ -536,7 +543,13 @@ declare namespace SplitIO {
        * @property {boolean} labelsEnabled
        * @default true
        */
-      labelsEnabled?: boolean
+      labelsEnabled?: boolean,
+      /**
+       * Disable impressions from being sent to Split backend. Should only be used to prevent duplicate tracking in situations like SSR.
+       * @property {boolean} impressionsEnabled
+       * @default true
+       */
+      impressionsEnabled?: boolean
     },
     /**
      * Mocked features map. For testing purposses only. For using this you should specify "localhost" as authorizationKey on core settings.


### PR DESCRIPTION
This adds an option `core.impressionsEnabled` that can be set to `false` to disable impression tracking. We can use this to correct our server-side experimentation logic, until Split adds support for something like this natively.