### PR TITLE
fix: ignore type error from incompatible NodeJS types

### DIFF
--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -279,6 +279,7 @@ interface INodeBasicSettings extends ISharedSettings {
  * @interface IStatusInterface
  * @extends NodeJS.Events
  */
+// @ts-ignore
 interface IStatusInterface extends NodeJS.Events {
   /**
    * Constant object containing the SDK events for you to use.


### PR DESCRIPTION
Ignoring this since we don't use Split anymore. It's causing issues since the referenced Node types are resolving to the Node types installed globally which are no longer compatible (NodeJS.Events is no longer exported). If we need SplitIO (with typings) longer term, we should make these typings and this library compatible with a newer version of Node (and its typings).